### PR TITLE
Configure custom domain pbct3ch.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pbct3ch.com

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ description: >- # used by seo meta and the atom feed
 
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.
-url: "https://srdsec.github.io"
+url: "https://pbct3ch.com"
 
 github:
   username: srdsec # change to your GitHub username


### PR DESCRIPTION
## Summary

Configures the site to serve on the apex custom domain **https://pbct3ch.com**:

- Adds a `CNAME` file containing `pbct3ch.com` (GitHub Pages copies this into the build and binds the domain).
- Updates `_config.yml` `url` → `https://pbct3ch.com` so canonical tags, the RSS feed, sitemap, and OpenGraph URLs use the custom domain.

## ⚠️ DNS change still required (not in this PR)

Right now `pbct3ch.com` points at **Squarespace**, which only does an HTTP redirect to `srdsec.github.io` and has no HTTPS certificate for the domain. For this to work, the DNS must be repointed at GitHub Pages at your DNS provider:

- **Apex `pbct3ch.com`** → A records:
  - `185.199.108.153`
  - `185.199.109.153`
  - `185.199.110.153`
  - `185.199.111.153`
- *(optional IPv6 AAAA)* `2606:50c0:8000::153`, `2606:50c0:8001::153`, `2606:50c0:8002::153`, `2606:50c0:8003::153`
- **`www.pbct3ch.com`** → CNAME `srdsec.github.io`
- Remove the existing Squarespace forwarding records for the apex and `www`.

After DNS propagates, set the custom domain under **Settings → Pages** (if not already) and enable **Enforce HTTPS**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>