### PR TITLE
Add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Ruby gems (Jekyll + Chirpy theme)
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "build(deps)"
+
+  # GitHub Actions used in the Pages deploy workflow
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable weekly **Dependabot version updates** (separate from the security alerts that were already on):

- **`bundler`** ecosystem — keeps Jekyll and the `jekyll-theme-chirpy` gem up to date.
- **`github-actions`** ecosystem — keeps the actions in the Pages deploy workflow current (e.g. the Node 20 deprecation warning on `configure-pages`/`upload-artifact`).

Both run weekly, are labelled `dependencies`, and use scoped commit-message prefixes.

## Context

Part of a repo security hardening pass. The following were also applied directly in repo settings:

- ✅ Secret scanning + push protection enabled
- ✅ Actions default `GITHUB_TOKEN` set to read-only (workflow grants its own scoped perms)
- ✅ Actions can no longer approve PRs
- ✅ Auto-delete head branches on merge
- ✅ Disabled the unused wiki

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>